### PR TITLE
Bug fix for Developing Windows Standalone on Mac

### DIFF
--- a/Assets/Klak/Spout/Runtime/Internal/PluginEntry.cs
+++ b/Assets/Klak/Spout/Runtime/Internal/PluginEntry.cs
@@ -10,7 +10,7 @@ namespace Klak.Spout
     {
         internal enum Event { Update, Dispose }
 
-        #if UNITY_STANDALONE_WIN
+        #if UNITY_STANDALONE_WIN && !UNITY_EDITOR_OSX
 
         internal static bool IsAvailable {
             get {


### PR DESCRIPTION
Added platform define symbol to check to see if developing for Windows on a Mac platform. Squashes dll not found errors